### PR TITLE
fix: discord does not receive args

### DIFF
--- a/cli/cmd/discord.go
+++ b/cli/cmd/discord.go
@@ -128,6 +128,10 @@ func chatOnDiscord() error {
 var discordCmd = &cobra.Command{
 	Use: "discord",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 0 {
+			return cmd.Help()
+		}
+
 		return chatOnDiscord()
 	},
 }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 24 Aug 23 22:12 UTC
This pull request fixes an issue where the Discord command was not receiving any arguments. The fix includes checking the length of the arguments and returning help if there are any arguments provided.
<!-- reviewpad:summarize:end -->
