### PR TITLE
fix: check discord bot command args

### DIFF
--- a/cli/cmd/discord.go
+++ b/cli/cmd/discord.go
@@ -128,6 +128,10 @@ func chatOnDiscord() error {
 var discordCmd = &cobra.Command{
 	Use: "discord",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 0 {
+			return cmd.Help()
+		}
+
 		return chatOnDiscord()
 	},
 }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 01 Sep 23 15:32 UTC
This pull request fixes an issue with checking discord bot command arguments. The fix ensures that if there are any arguments provided, the help command is executed instead.
<!-- reviewpad:summarize:end -->
